### PR TITLE
Plugin code block must be identifiable by CSS

### DIFF
--- a/djangocms_video/templates/djangocms_video/default/video_player.html
+++ b/djangocms_video/templates/djangocms_video/default/video_player.html
@@ -1,29 +1,32 @@
 {% load i18n cms_tags %}
 
-{% if instance.embed_link %}
-    {# show iframe if embed_link is provided #}
-    <iframe src="{{ instance.embed_link_with_parameters }}" {{ instance.attributes_str }} frameborder="0" allowfullscreen="true"></iframe>
-    {% with disabled=instance.embed_link %}
-        {% for plugin in instance.child_plugin_instances %}
-            {% render_plugin plugin %}
-        {% endfor %}
-    {% endwith %}
-{% else %}
-    {# render <source> or <track> plugins #}
-    <video controls {{ instance.attributes_str }}
-        {% if instance.poster %} poster="{{ instance.poster.url }}"{% endif %}>
-        {% for plugin in instance.child_plugin_instances %}
-            {% render_plugin plugin %}
-        {% endfor %}
-        {% trans "Your browser doesn't support this video format." %}
-    </video>
-{% endif %}
 
-{% comment %}
-    # Available variables:
-    {{ instance.template }}
-    {{ instance.label }}
-    {{ instance.embed_link }}
-    {{ instance.poster }}
-    {{ instance.attributes_str }}
-{% endcomment %}
+<div class="djangocms-video-plugin">
+    {% if instance.embed_link %}
+        {# show iframe if embed_link is provided #}
+        <iframe src="{{ instance.embed_link_with_parameters }}" {{ instance.attributes_str }} frameborder="0" allowfullscreen="true"></iframe>
+        {% with disabled=instance.embed_link %}
+            {% for plugin in instance.child_plugin_instances %}
+                {% render_plugin plugin %}
+            {% endfor %}
+        {% endwith %}
+    {% else %}
+        {# render <source> or <track> plugins #}
+        <video controls {{ instance.attributes_str }}
+            {% if instance.poster %} poster="{{ instance.poster.url }}"{% endif %}>
+            {% for plugin in instance.child_plugin_instances %}
+                {% render_plugin plugin %}
+            {% endfor %}
+            {% trans "Your browser doesn't support this video format." %}
+        </video>
+    {% endif %}
+
+    {% comment %}
+        # Available variables:
+        {{ instance.template }}
+        {{ instance.label }}
+        {{ instance.embed_link }}
+        {{ instance.poster }}
+        {{ instance.attributes_str }}
+    {% endcomment %}
+</div>


### PR DESCRIPTION
resolves #57 and works around issues raised by @FinalAngel . The CSS can be added separately as per https://github.com/django-cms/djangocms-template frontend example however we don't want developers have to override this plugin's HTML template all the time.