### PR TITLE
Removed pinned django-treebeard

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@ Changelog
 =========
 
 
+Unreleased
+==================
+
+* Removed (pinned) django-treebeard dependency
+
+
 3.0.0 (2020-09-02)
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ REQUIREMENTS = [
     'django-cms>=3.7',
     'django-filer>=1.7',
     'djangocms-attributes-field>=1',
-    'django-treebeard>=4.3,<4.5',
 ]
 
 


### PR DESCRIPTION
## Description
This change removes an old issue protecting broken changes in django-treebeard 4.5.0 where the core CMS and treebeard has since received patches.

## Related resources
* Issue introduced in 4.5: https://github.com/django-treebeard/django-treebeard/blob/master/CHANGES.md#release-45-feb-17-2021
* Resolved in 4.5.1: https://github.com/django-treebeard/django-treebeard/blob/master/CHANGES.md#release-451-feb-22-2021

## Checklist
* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.