### PR TITLE
feat: Add referrer policy to iframe in video player template

### DIFF
--- a/djangocms_video/templates/djangocms_video/default/video_player.html
+++ b/djangocms_video/templates/djangocms_video/default/video_player.html
@@ -4,7 +4,7 @@
 <div class="djangocms-video-plugin">
     {% if instance.embed_link %}
         {# show iframe if embed_link is provided #}
-        <iframe src="{{ instance.embed_link_with_parameters }}" {{ instance.attributes_str }} frameborder="0" allowfullscreen="true"></iframe>
+        <iframe src="{{ instance.embed_link_with_parameters }}" {{ instance.attributes_str }} referrerpolicy="strict-origin-when-cross-origin" frameborder="0" allowfullscreen="true"></iframe>
         {% with disabled=instance.embed_link %}
             {% for plugin in instance.child_plugin_instances %}
                 {% render_plugin plugin %}


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Specify a strict-origin-when-cross-origin referrer policy on the video player iframe in the default template.

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.